### PR TITLE
Point to "in_data" for all files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,9 +2,12 @@
 .Rhistory
 .RData
 .Ruserdata
+.RProj
 
 out_data/*
 !out_data/.empty
 
 in_data/*
 !in_data/.empty
+
+.remake/*

--- a/2_observations.yml
+++ b/2_observations.yml
@@ -28,11 +28,11 @@ targets:
   
   # make sure we publish the "raw" version and the "aggregated" version of 
   # the temperature data. Raw should be matched but not aggregated to one value per reach/day
-  out_data/temperature_observations_drb.zip:
-    command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/obs_temp_full.csv')
+  #out_data/temperature_observations_drb.zip:
+   # command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/obs_temp_full.csv')
 
-  out_data/flow_observations_drb.zip:
-    command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/obs_flow_full.csv')
+  #out_data/flow_observations_drb.zip:
+   # command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/obs_flow_full.csv')
 
   # reservoir observations
   ##### Transfer and filtering of files of file from lake-temperature-model-prep #####
@@ -43,29 +43,25 @@ targets:
   out_data/reservoir_temp_obs.csv:
     command: fetch_filter_tibble(
       out_csv = target_name,
-      in_ind = '../lake-temperature-model-prep/7b_temp_merge/out/drb_daily_reservoir_temps.rds.ind',
-      in_repo = I('../lake-temperature-model-prep/'),
+      in_dat = 'in_data/drb_daily_reservoir_temps.rds',
       site_ids = reservoir_modeling_site_ids)
     
   out_data/reservoir_level_nwis.csv:
     command: fetch_filter_tibble(
       out_csv = target_name,
-      in_ind = '../lake-temperature-model-prep/7a_nwis_munge/out/drb_reservoirs_waterlevels_munged.rds.ind',
-      in_repo = I('../lake-temperature-model-prep/'),
+      in_dat = 'in_data/drb_reservoirs_waterlevels_munged.rds',
       site_ids = reservoir_modeling_site_ids)
       
   out_data/reservoir_level_nycdep.rds:
     command: fetch_filter_nycdep(
       out_rds = target_name,
-      in_ind = '../lake-temperature-model-prep/7a_nwis_munge/out/NYC_DEP_reservoir_waterlevels.rds.ind',
-      in_repo = I('../lake-temperature-model-prep/'),
+      in_dat = 'in_data/NYC_DEP_reservoir_waterlevels.rds',
       site_ids = reservoir_modeling_site_ids)
       
   out_data/reservoir_level_usgs_historical.rds:
     command: fetch_filter_historical(
       out_rds = target_name,
-      in_ind = '../delaware-model-prep/2_observations/out/interpolated_daily_reservoir_water_budget_components.csv.ind',
-      in_repo = I('../delaware-model-prep/'),
+      in_dat = 'in_data/interpolated_daily_reservoir_water_budget_components.csv',
       xwalk = I(c('Cannonsville' = 'nhdhr_120022743', 'Pepacton' = 'nhdhr_151957878')))
       
   out_data/reservoir_level_obs.csv:
@@ -76,7 +72,5 @@ targets:
       hist_levels = 'out_data/reservoir_level_usgs_historical.rds')
       
   out_data/reservoir_releases_by_type.csv:
-    command: file.copy('../delaware-model-prep/2_observations/out/reservoir_releases_by_type_drb.csv', to = target_name)
+    command: file.copy('in_data/reservoir_releases_by_type_drb.csv', to = target_name)
     
-  out_data/reservoir_diversions.csv:
-    command: file.copy('../delaware-model-prep/2_observations/out/reservoir_diversions.csv', to = target_name)

--- a/3_driver.yml
+++ b/3_driver.yml
@@ -59,6 +59,6 @@ targets:
   # out_data/reservoir_interpolated_daily_water_budget_components.csv:
   #   command: file.copy(from = '../delaware-model-prep/2_observations/out/interpolated_daily_reservoir_water_budget_components.csv', to = target_name)
 
-  out_data/gridmet_drb_agg_v2.csv.zip:
-    command: file.copy(from = '/Users/msleckman/USGS/GS-WMA-IWP-PUMP/Data-driven Salinity/Inland Salinity/drb_gridmet_tools/data/OutputFolder/gridmet_drb_agg_v2.csv.zip', to = target_name)
+  out_data/gridmet_drb_agg.csv.zip:
+    command: file.copy(from = 'in_data/gridmet_drb_agg_v2.csv.zip', to = target_name)
     

--- a/3_driver.yml
+++ b/3_driver.yml
@@ -20,7 +20,7 @@ targets:
       # - out_data/reservoir_features.csv
       # - out_data/sntemp_inputs_outputs.zip
       # - out_data/reservoir_interpolated_daily_water_budget_components.csv
-        - out_data/gridmet_drb_agg_v2.csv.zip
+        - out_data/gridmet_drb_agg.csv.zip
       
 
   #weather_drivers:

--- a/in_text/text_03_driver.yml
+++ b/in_text/text_03_driver.yml
@@ -1,7 +1,5 @@
 title: >-
-  Data release to support multiple modeling efforts in the Delaware River Basin: Driver data files XX
-  
-  TEST
+  TEST Data release to support multiple modeling efforts in the Delaware River Basin: Driver data files XX
   
 abstract: >-
   Meteorological data (Met data) serve as data driving for modeling and freshwater temperature in the Delaware River Basin.  

--- a/log/02_observations_sb_data.csv
+++ b/log/02_observations_sb_data.csv
@@ -1,5 +1,5 @@
 filepath,sb_id,time_uploaded_to_sb
-out_data/reservoir_temp_obs.csv,623e550ad34e915b67d8366e,2022-04-03 18:45 UTC
-out_data/reservoir_level_obs.csv,623e550ad34e915b67d8366e,2022-04-19 21:55 UTC
-out_data/reservoir_releases_by_type.csv,623e550ad34e915b67d8366e,2022-04-03 18:45 UTC
-in_data/reservoir_diversions.csv,623e550ad34e915b67d8366e,2022-04-19 21:55 UTC
+out_data/reservoir_temp_obs.csv,623e550ad34e915b67d8366e,2022-04-19 23:07 UTC
+out_data/reservoir_level_obs.csv,623e550ad34e915b67d8366e,2022-04-19 23:07 UTC
+out_data/reservoir_releases_by_type.csv,623e550ad34e915b67d8366e,2022-04-19 23:07 UTC
+in_data/reservoir_diversions.csv,623e550ad34e915b67d8366e,2022-04-19 23:07 UTC

--- a/log/02_observations_sb_data.csv
+++ b/log/02_observations_sb_data.csv
@@ -1,5 +1,5 @@
 filepath,sb_id,time_uploaded_to_sb
 out_data/reservoir_temp_obs.csv,623e550ad34e915b67d8366e,2022-04-03 18:45 UTC
-out_data/reservoir_level_obs.csv,623e550ad34e915b67d8366e,2022-04-03 18:45 UTC
+out_data/reservoir_level_obs.csv,623e550ad34e915b67d8366e,2022-04-19 21:55 UTC
 out_data/reservoir_releases_by_type.csv,623e550ad34e915b67d8366e,2022-04-03 18:45 UTC
-out_data/reservoir_diversions.csv,623e550ad34e915b67d8366e,2022-04-03 18:45 UTC
+in_data/reservoir_diversions.csv,623e550ad34e915b67d8366e,2022-04-19 21:55 UTC

--- a/remake.yml
+++ b/remake.yml
@@ -95,7 +95,7 @@ targets:
       file_name = target_name,
       sb_id = sbid_03_driver,
       sources = 'src/sb_utils.R',
-      'out_data/gridmet_drb_agg_v2.csv.zip')
+      'out_data/gridmet_drb_agg.csv.zip')
 
   03_driver_sb_xml:
     command: sb_render_post_xml(sbid_03_driver,

--- a/remake.yml
+++ b/remake.yml
@@ -92,7 +92,7 @@ targets:
   
   log/03_driver_sb_data.csv:
     command: sb_replace_files(
-      file_name = target_name,
+      filename = target_name,
       sb_id = sbid_03_driver,
       sources = 'src/sb_utils.R',
       'out_data/gridmet_drb_agg.csv.zip')

--- a/remake.yml
+++ b/remake.yml
@@ -97,11 +97,11 @@ targets:
       sources = 'src/sb_utils.R',
       'out_data/gridmet_drb_agg.csv.zip')
 
-  03_driver_sb_xml:
-    command: sb_render_post_xml(sbid_03_driver,
-      xml_file = I('03_driver.xml'),
-      "in_text/text_SHARED.yml",
-      "in_text/text_03_driver.yml")
+  # 03_driver_sb_xml:
+  #   command: sb_render_post_xml(sbid_03_driver,
+  #     xml_file = I('03_driver.xml'),
+  #     "in_text/text_SHARED.yml",
+  #     "in_text/text_03_driver.yml")
   #      river_metadata2
   # 
   # out_xml/03_driver_fgdc_metadata.xml:

--- a/remake.yml
+++ b/remake.yml
@@ -21,7 +21,6 @@ packages:
 sources:
   #- src/spatial_utils.R
   - src/sb_utils.R
-  - src/sb_functions.R
 
 targets:
   all:
@@ -32,7 +31,7 @@ targets:
       - log/02_observations_sb_data.csv
       #- 02_observations_sb_xml
       # - 03_driver_sb_xml
-      - 03_driver_sb_data
+      - log/03_driver_sb_data.csv
       # - 03_driver_sb_meteo
 
 # in case you want to mess w/ the xml alone:
@@ -75,8 +74,8 @@ targets:
       sources = 'src/sb_utils.R',
       "out_data/reservoir_temp_obs.csv",
       "out_data/reservoir_level_obs.csv",
-      'out_data/reservoir_releases_by_type.csv',
-      'out_data/reservoir_diversions.csv')
+      "out_data/reservoir_releases_by_type.csv",
+      'in_data/reservoir_diversions.csv')
 
   # 02_observations_sb_xml:
   #   command: sb_render_post_xml(sbid_02_observations,
@@ -91,30 +90,11 @@ targets:
   #     "in_text/text_02_observations.yml",
   #     river_metadata2)
   
-
-  # 
-  # OLD - 02_observations_sb_data - 
-  # 02_observations_sb_data:
-  #   command: sb_replace_files(sbid_02_observations,
-  #     "out_data/temperature_observations_drb.zip",
-  #     "out_data/temperature_observations_lordville.zip",
-  #     "out_data/temperature_observations_forecast_sites.zip",
-  #     "out_data/flow_observations_drb.zip",
-  #     "out_data/flow_observations_lordville.zip",
-  #     "out_data/flow_observations_forecast_sites.zip",
-  #     "out_data/reservoir_releases_total.csv",
-  #     "out_data/reservoir_releases_by_type_drb.csv",
-  #     "out_data/reservoir_releases_by_type_lordville.csv",
-  #     "out_data/reservoir_realsat_monthly_surface_area.csv",
-  #     "out_data/reservoir_io_obs.csv",
-  #     "out_data/reservoir_temp_obs.csv",
-  #     "out_data/reservoir_level_obs.csv"
-  #     
-  #     )
-
-  03_driver_sb_data:
+  log/03_driver_sb_data.csv:
     command: sb_replace_files(
-      sbid_03_driver,
+      file_name = target_name,
+      sb_id = sbid_03_driver,
+      sources = 'src/sb_utils.R',
       'out_data/gridmet_drb_agg_v2.csv.zip')
 
   03_driver_sb_xml:
@@ -122,7 +102,7 @@ targets:
       xml_file = I('03_driver.xml'),
       "in_text/text_SHARED.yml",
       "in_text/text_03_driver.yml")
-#      river_metadata2
+  #      river_metadata2
   # 
   # out_xml/03_driver_fgdc_metadata.xml:
   #   command: render(filename = target_name,

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -6,7 +6,7 @@
 # navigates you into another repo and the part that should be used to call
 # gd_get within that repo.
 
-fetch_filter_res_polygons <- function(out_rds, in_ind, in_repo, site_ids) {
+fetch_filter_res_polygons <- function(out_rds, in_dat, in_repo, site_ids) {
   # pull the data file down to that other repo
   gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
 
@@ -18,24 +18,19 @@ fetch_filter_res_polygons <- function(out_rds, in_ind, in_repo, site_ids) {
   # return object rather than writing file as other functions in this .R file do
 }
 
-fetch_filter_tibble <- function(out_csv, in_ind, in_repo, site_ids) {
-  # pull the data file down to that other repo
-  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
+fetch_filter_tibble <- function(out_csv, in_dat, site_ids) {
 
   # read and filter to just the specified sites
-  as_data_file(in_ind) %>%
-    readRDS() %>%
+  readRDS(in_dat) %>%
     filter(site_id %in% !!site_ids) %>%
     readr::write_csv(out_csv)
 }
 
-fetch_filter_nycdep <- function(out_rds, in_ind, in_repo, site_ids) {
+fetch_filter_nycdep <- function(out_rds, in_dat, site_ids) {
   # pull the data file down to that other repo
-  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
 
   # read and filter to just the specified sites
-  nycdep_data <- as_data_file(in_ind) %>%
-    readRDS() %>%
+  nycdep_data <- readRDS(in_dat) %>%
     filter(site_id %in% !!site_ids)
 
   # filter out erroneous Pepacton observation and save as rds
@@ -43,12 +38,11 @@ fetch_filter_nycdep <- function(out_rds, in_ind, in_repo, site_ids) {
     saveRDS(out_rds)
 }
 
-fetch_filter_historical <- function(out_rds, in_ind, in_repo, xwalk) {
-  # pull the data file down to that other repo
-  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
+fetch_filter_historical <- function(out_rds, in_dat, xwalk) {
+
 
   # read and filter to just the specified sites
-  as_data_file(in_ind) %>%
+  in_dat %>%
     readr::read_csv(col_types = 'ccnnncnnnnnnnnnc') %>%
     mutate(site_id = xwalk[reservoir]) %>%
     filter(site_id %in% as.character(xwalk)) %>%


### PR DESCRIPTION
This converts all existing data pushes to point to an "in_data" folder for easier conversion when we're ready to move to HPC/caldera.

@msleckman - note I updated your driver push in `remake.yml` to follow the new pattern of writing a log file to a csv. Please modify your GridMET target to point directly to "in_data" to follow a similar pattern.