### PR TITLE
add temperature and flow data

### DIFF
--- a/1_spatial.yml
+++ b/1_spatial.yml
@@ -53,14 +53,14 @@ targets:
       sf_object = modeled_network_sf,
       layer_name = I('study_stream_reaches'))
 
-#  let's change this to be all reservoir polygons in the DRB
-#  from the global reservoir data base
+  #  let's change this to be all reservoir polygons in the DRB
+  #  from the global reservoir data base
   reservoir_polygons:
-  command: fetch_filter_res_polygons(
-    out_rds = target_name,
-    in_ind = "in_data/03_driver/canonical_lakes_sf.rds.ind",
-    in_repo = NULL,
-    site_ids = reservoir_modeling_site_ids)
+    command: fetch_filter_res_polygons(
+      out_rds = target_name,
+      in_dat = "in_data/03_driver/canonical_lakes_sf.rds.",
+      in_repo = NULL,
+      site_ids = reservoir_modeling_site_ids)
       
   #reservoir_metadata:
     #command: extract_feature(reservoir_polygons)

--- a/2_observations.yml
+++ b/2_observations.yml
@@ -28,11 +28,14 @@ targets:
   
   # make sure we publish the "raw" version and the "aggregated" version of 
   # the temperature data. Raw should be matched but not aggregated to one value per reach/day
-  #out_data/temperature_observations_drb.zip:
-   # command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/obs_temp_full.csv')
+  out_data/unaggregated_temperature_observations_drb.zip:
+    command: zip_obs(out_file = target_name, in_file = 'in_data/02_observations/obs_temp_drb_raw.rds')
+  
+  out_data/aggregated_temperature_observations_drb.zip:
+    command: zip_obs(out_file = target_name, in_file = 'in_data/02_observations/obs_temp_drb.rds')
 
-  #out_data/flow_observations_drb.zip:
-   # command: zip_obs(out_file = target_name, in_file = '../delaware-model-prep/9_collaborator_data/umn/obs_flow_full.csv')
+  out_data/flow_observations_drb.zip:
+    command: zip_obs(out_file = target_name, in_file = 'in_data/02_observations/obs_flow_drb.rds')
 
   # reservoir observations
   ##### Transfer and filtering of files of file from lake-temperature-model-prep #####

--- a/2_observations.yml
+++ b/2_observations.yml
@@ -12,7 +12,8 @@ sources:
 targets:
   2_observations:
     depends:
-      - out_data/temperature_observations_drb.zip
+      - out_data/unaggregated_temperature_observations_drb.zip
+      - out_data/aggregated_temperature_observations_drb.zip
       - out_data/flow_observations_drb.zip
       - out_data/reservoir_level_obs.csv
       - out_data/reservoir_temp_obs.csv

--- a/3_driver.yml
+++ b/3_driver.yml
@@ -60,7 +60,7 @@ targets:
   out_data/gridmet_drb_agg.csv.zip:
     command: zip_this(out_file = target_name, .object = 'out_data/gridmet_drb_agg.csv')
     
-      out_data/gridmet_drb_agg.nc:
+  out_data/gridmet_drb_agg.nc:
     command: file.copy(from = 'in_data/03_driver/drb_climate_2022_04_06.nc', to = target_name)
     
   out_data/gridmet_drb_agg.nc.zip:

--- a/remake.yml
+++ b/remake.yml
@@ -76,7 +76,10 @@ targets:
       "out_data/reservoir_temp_obs.csv",
       "out_data/reservoir_level_obs.csv",
       "out_data/reservoir_releases_by_type.csv",
-      'in_data/02_observations/reservoir_diversions.csv')
+      'in_data/02_observations/reservoir_diversions.csv',
+      'out_data/unaggregated_temperature_observations_drb.zip',
+      'out_data/aggregated_temperature_observations_drb.zip',
+      'out_data/flow_observations_drb.zip')
 
   # 02_observations_sb_xml:
   #   command: sb_render_post_xml(sbid_02_observations,
@@ -98,7 +101,7 @@ targets:
       sources = 'src/sb_utils.R',
       'out_data/gridmet_drb_agg.csv.zip',
       'out_data/gridmet_drb_agg.nc.zip',
-      'out_data/out_data/reanalysis_gefs_fy22.csv.zip',
+      'out_data/reanalysis_gefs_fy22.csv.zip',
       'out_data/uncal_sntemp_input_output.nc.zip'
       )
 

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -6,7 +6,7 @@
 # navigates you into another repo and the part that should be used to call
 # gd_get within that repo.
 
-fetch_filter_res_polygons <- function(out_rds, in_dat,, site_ids, in_repo = NULL) {
+fetch_filter_res_polygons <- function(out_rds, in_dat, site_ids, in_repo = NULL) {
   # pull the data file down to that other repo
   if(!is.null(in_repo)){
   gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -7,12 +7,9 @@
 # gd_get within that repo.
 
 fetch_filter_res_polygons <- function(out_rds, in_dat, site_ids, in_repo = NULL) {
-  # pull the data file down to that other repo
-  if(!is.null(in_repo)){
-  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
-  }
+
   # read and filter to just the specified sites
-  as_data_file(in_ind) %>%
+  as_data_file(in_dat) %>%
     readRDS() %>%
     filter(site_id %in% !!site_ids) %>%
     st_zm(drop = TRUE, what = "ZM") # the canonical lakes file has 3D multipolygons but the Z range is 0 to 0, so let's drop it down to 2D

--- a/src/file_functions.R
+++ b/src/file_functions.R
@@ -90,23 +90,6 @@ filter_res_ids <- function(in_file, out_file, res_keep) {
   readr::write_csv(dat, out_file)
 }
 
-#' Call gd_get (without any scipiper target builds) on a file in another repo on
-#' this file system, downloading that file from a shared Drive cache into that
-#' other repo
-#'
-#' @param ind_file the indicator file of the data file in the other repo, to be
-#'   downloaded to the corresponding location in that other repo
-#' @param repo the relative file path of the other repo. Usually it'll be right
-#'   alongside the current repo, e.g., '../lake-temperature-model-prep'
-gd_get_elsewhere <- function(ind_file, repo, ...) {
-  # switch to the elsewhere repo, with plans to always switch back to this one before exiting the function
-  this_repo <- getwd()
-  on.exit(setwd(this_repo))
-  setwd(repo)
-
-  # fetch the file down to that elsewhere repo
-  gd_get(ind_file, ...)
-}
 
 # Write a layer of an sf object as a zipped-up shapefile
 sf_to_zip <- function(zip_filename, sf_object, layer_name){


### PR DESCRIPTION
Add aggregated (to the reach-date) and unaggregated (but only sites matched to PRMS reaches) temperature observations, as well as flow observations. Last year we only published aggregated data. 

Note some file path cleanups - hopefully these are right. Couldn't add files to `in_data` on Caldera as I don't have the correct file permissions.