### PR TITLE
Adding spatial file targets to the drb-temp repo (not metadata)

### DIFF
--- a/1_spatial.yml
+++ b/1_spatial.yml
@@ -13,9 +13,9 @@ sources:
 targets:
   1_spatial:
     depends:
-      - river_metadata
+      - river_metadata_segs
       - out_data/study_stream_reaches.zip
-      - reservoir_metadata
+      - reservoir_metadata_verts
       - out_data/study_reservoirs.zip
       - out_data/study_monitoring_sites.zip
     
@@ -37,16 +37,15 @@ targets:
   #hrus_sf:
     #command: retrieve_hrus(hrus_sf_fl = 'XX')
   
-  # include map of network, maybe with HRUs?
   #out_data/modeling_domain_map.png:
    # command: plot_domain_map(target_name,
     #  network_sf = modeled_network_sf,
       #plot_crs = I("+init=epsg:2811"))
     
-  river_metadata:
+  river_metadata_segs:
     command: extract_feature(network_vertices_sf)
     
-  river_metadata2:
+  river_metadata_verts:
     command: extract_feature(modeled_network_sf)
     
   out_data/study_stream_reaches.zip:

--- a/1_spatial.yml
+++ b/1_spatial.yml
@@ -58,16 +58,16 @@ targets:
   reservoir_polygons:
   command: fetch_filter_res_polygons(
     out_rds = target_name,
-    in_ind = "in_data/03_driver/canonical_lakes_sf.rds.ind",
+    in_dat = "in_data/01_spatial/canonical_lakes_sf.rds",
     in_repo = NULL,
     site_ids = reservoir_modeling_site_ids)
       
-  #reservoir_metadata:
-    #command: extract_feature(reservoir_polygons)
+  reservoir_metadata:
+    command: extract_feature(reservoir_polygons)
     
-  #out_data/study_reservoirs.zip:
-   # command: sf_to_zip(zip_filename = target_name, 
-    #  sf_object = reservoir_polygons, layer_name = I('study_reservoirs'))
+  out_data/study_reservoirs.zip:
+    command: sf_to_zip(zip_filename = target_name,
+    sf_object = reservoir_polygons, layer_name = I('study_reservoirs'))
       
   monitoring_sites:
     command: readRDS(file = 'in_data/03_driver/drb_filtered_sites_qa.rds')

--- a/1_spatial.yml
+++ b/1_spatial.yml
@@ -71,7 +71,7 @@ targets:
     #  sf_object = reservoir_polygons, layer_name = I('study_reservoirs'))
       
   monitoring_sites:
-    command: readRDS(file = 'in_data/03_driver/drb_filtered_sites.rds')
+    command: readRDS(file = 'in_data/03_driver/drb_filtered_sites_qa.rds')
     
   out_data/study_monitoring_sites.zip:
     command: reduce_and_zip(zip_filename = target_name, 

--- a/remake.yml
+++ b/remake.yml
@@ -40,7 +40,7 @@ targets:
   #   command: render(filename = target_name,
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_00_parent.yml")
-#       river_metadata2)
+#       river_metadata_verts)
   # 
   00_parent_sb_xml:
     command: sb_render_post_xml(sbid_00_parent,
@@ -48,20 +48,20 @@ targets:
       "in_text/text_SHARED.yml",
       "in_text/text_00_parent.yml")
       # ,
-      # river_metadata2)
+      # river_metadata_verts)
   # 
   # 01_spatial_sb_xml:
   #   command: sb_render_post_xml(sbid_01_spatial,
   #     xml_file = I('01_spatial.xml'),
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_01_spatial.yml",
-  #     river_metadata2)
+  #     river_metadata_verts)
   #     
   # out_xml/01_spatial_fgdc_metadata.xml:
   #   command: render(filename = target_name,
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_01_spatial.yml",
-  #     river_metadata2)
+  #     river_metadata_verts)
   # 
   # 01_spatial_sb_shp:
   #   command: sb_replace_files(sbid_01_spatial,
@@ -84,13 +84,13 @@ targets:
   #     xml_file = I('02_observations.xml'),
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_02_observations.yml",
-  #     river_metadata2)
+  #     river_metadata_verts)
   #     
   # out_xml/02_observations_fgdc_metadata.xml:
   #   command: render(filename = target_name,
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_02_observations.yml",
-  #     river_metadata2)
+  #     river_metadata_verts)
   
   log/03_driver_sb_data.csv:
     command: sb_replace_files(
@@ -108,13 +108,13 @@ targets:
       xml_file = I('03_driver.xml'),
       "in_text/text_SHARED.yml",
       "in_text/text_03_driver.yml")
-  #      river_metadata2
+  #      river_metadata_verts
   # 
   # out_xml/03_driver_fgdc_metadata.xml:
   #   command: render(filename = target_name,
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_03_driver.yml")
-  #     #river_metadata2
+  #     #river_metadata_verts
   #     )
   # 
 
@@ -122,7 +122,7 @@ targets:
   #     xml_file = I('04_inputs.xml'),
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_04_inputs.yml",
-  #     river_metadata2)
+  #     river_metadata_verts)
 
 
 # 4 inputs will include
@@ -142,7 +142,7 @@ targets:
   #   command: render(filename = target_name,
   #     "in_text/text_SHARED.yml",
   #     "in_text/text_04_inputs.yml",
-  #     river_metadata2)
+  #     river_metadata_verts)
 
 # 04_inputs_sb_meteo:
   #   command: sb_replace_files(sbid_04_inputs,

--- a/src/fetch_filter_functions.R
+++ b/src/fetch_filter_functions.R
@@ -9,10 +9,17 @@
 fetch_filter_res_polygons <- function(out_rds, in_dat, site_ids, in_repo = NULL) {
   # pull the data file down to that other repo
   if(!is.null(in_repo)){
-  gd_get_elsewhere(gsub(in_repo, '', in_ind, fixed=TRUE), in_repo)
+  gd_get_elsewhere(gsub(in_repo, '', in_dat, fixed=TRUE), in_repo)
   }
+  
+  if(endsWith(in_dat, 'rds.ind')){
+    data <- as_data_file(in_dat) }
+  if(endsWith(in_dat, '.rds')){
+    data <- in_dat} 
+  else{stop('in_dat should be rds file of indicator rds file (rds.ind)')}
+  
   # read and filter to just the specified sites
-  as_data_file(in_ind) %>%
+  data %>%
     readRDS() %>%
     filter(site_id %in% !!site_ids) %>%
     st_zm(drop = TRUE, what = "ZM") # the canonical lakes file has 3D multipolygons but the Z range is 0 to 0, so let's drop it down to 2D
@@ -112,4 +119,5 @@ copy_filter_feather <- function(out_csv, in_feather, site_ids) {
   arrow::read_feather(in_feather) %>%
     filter(res_id %in% site_ids) %>%
     readr::write_csv(out_csv)
+
 }


### PR DESCRIPTION
A lot of baseline changes on 1_spatial.yml have already been merged to main. 

I've transferred over the files I deemed needed in this release and that match with the spatial data files fro last year's release:

in_data/01_spatial

    river shapefiles :

    `network.rds`
    `segments_relative_to_reservoirs.rds`

    reservoir shapefiles:

    `reservoir_features.csv` (no lat lon)
    `canonical_lakes_sf.rds` (copied from lake-temperature-model-prep/1_crosswalk_fetch/out/ in caldera

    site shapefile:

    `drb_filtered_sites_qa.rds`

Please let me know what is missing, what to keep, and what needs to be moved. Changes can be viewed in PR https://github.com/USGS-R/drb-temp-data-release-v2/pull/12 as well. 

I have also: 
- Edited the filtered_sites rds target to get the updated one from Delaware model prep  (`drb_filtered_sites_qa.rds`)
- Renamed metadata objects `river_metadata` and `river_metadata2` to `river_metadata_segs` (network segments) and `river_metadata_verts` (vertices) although the content of metadata is similar. (commit https://github.com/USGS-R/drb-temp-data-release-v2/pull/15/commits/325a44bf5ca9d7ea126d14773ebf26471c23f6bf)

