### PR TITLE
small changes from final review

### DIFF
--- a/in_text/text_00_parent.yml
+++ b/in_text/text_00_parent.yml
@@ -21,7 +21,7 @@ abstract: >-
   at all reaches in the DRB.
 
 
-  <p> This data compilation was funded by the USGS.
+  <p> This data compilation was funded by the USGS.</p>
 
 cross-cites:
   -

--- a/in_text/text_02_observations.yml
+++ b/in_text/text_02_observations.yml
@@ -16,9 +16,11 @@ abstract: >-
   The data are formatted as a single csv (comma separated values) or zipped csv.
 
 
-  Site observation data was matched to stream reach segments, and the data files included contain identifiers for
+
+  Site observation data were matched to stream reach segments, and the data files included contain identifiers for
   both observation sites and affiliated stream reaches. Please see metadata for <li><a href="https://www.sciencebase.gov/catalog/item/623e54c4d34e915b67d83580"> 1) Spatial data for rivers, reservoirs, and monitoring
   locations </a> for further information on how monitoring location sites were matched to river segments.</li>
+
 
 
   For modeling purposes, we created a holdout test set of flow and temperature observations that were

--- a/in_text/text_03_driver.yml
+++ b/in_text/text_03_driver.yml
@@ -525,7 +525,7 @@ entities:
     -
       attr-label: geomid
       attr-def: >-
-        Local model hru id. This attribute is a product of the xarray package through the regridding of the meteorological spatial data (raster format) to the spatial polygon input. For this study, the spatial polygon input is the Delaware River Basin PRMS HRU polygon geopackage. 
+        Local model hru id. This attribute is a product of the xarray package through the regridding of the meteorological spatial data (raster format) to the spatial polygon input. For this study, the spatial polygon input is the Delaware River Basin PRMS HRU polygon geopackage.
         This ID attribute is used to match back to the PRMS HRU IDs of catchment geopackage, to 1) run PRMS-SNTemp and to 2) produce the gridmet_drb_agg.csv.
       attr-defs: https://doi.org/10.1002/joc.3413
       data-min: NA

--- a/remake.yml
+++ b/remake.yml
@@ -142,8 +142,8 @@ targets:
       'out_data/distance_matrix_drb.csv',
       'out_data/gridmet_drb_agg_csv.zip',
       'out_data/gridmet_drb_agg_nc.zip',
-      'out_data/reanalysis_gefs_drb.csv.zip',
-      'out_data/uncal_sntemp_input_output.nc.zip',
+      'out_data/reanalysis_gefs_drb.zip',
+      'out_data/uncal_sntemp_input_output.zip',
       'out_xml/03_driver_fgdc_metadata.xml'
       )
 


### PR DESCRIPTION
This hopefully fixes some spacing issues as well as naming conventions for .zip files.

Note, we also need to rebuild .xml files on HPC with new version of meddle so that the expression gets executed for date. E.g., currently the version on Sciencebase shows `Process Date: format(Sys.time(),'%Y%m%d')`.